### PR TITLE
Solución a multiples modificaciones de CUIL

### DIFF
--- a/export_lsd/tools/export_advanced_txt.py
+++ b/export_lsd/tools/export_advanced_txt.py
@@ -723,7 +723,6 @@ def employess_info_from_excel(file_import: Path) -> dict:
     df = pd.read_excel(file_import)
 
     for index, row in df.iterrows():
-
         if not is_positive_number(str(row['Leg'])):
             employees_dict['invalid_data'].append(f"Línea: {index} - Legajo {row['Leg']} Inválido")
             continue

--- a/export_lsd/tools/import_empleados.py
+++ b/export_lsd/tools/import_empleados.py
@@ -100,7 +100,9 @@ def new_employees_from_xlsx(filepath: str, empresa: SimpleLazyObject):
             bulk_mgr.add(Empleado(empresa=empresa, leg=row['Leg'], name="Creado por Importación",
                                   cuil=row['CUIL'], area='', cbu=cbu))
         else:
-            # Existe, lo actualizo
-            this_empleado = Empleado.objects.filter(leg=row['Leg'])
-            this_empleado.update(cuil=row['CUIL'], cbu=cbu)
+            # Existe, lo actualizo. Debe ser sólo 1 registro
+            this_empleado = Empleado.objects.get(leg=row['Leg'], empresa=empresa)
+            this_empleado.cuil = str(row['CUIL'])
+            this_empleado.cbu = str(cbu)
+            this_empleado.save()
     bulk_mgr.done()


### PR DESCRIPTION
### Solución a multiples modificaciones de CUIL

Sucedía ante información de legajos en exportación masiva de período por excel
Ocurría sólo cuando el legajo existía.