### PR TITLE
Lectura excel info empleados hasta que fila vacía

### DIFF
--- a/el_conta/urls.py
+++ b/el_conta/urls.py
@@ -20,4 +20,4 @@ urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 urlpatterns += static(settings.TEMP_URL, document_root=settings.TEMP_ROOT)
 
-handler404 = error_404
+handler404 = error_404  # noqa

--- a/export_lsd/tools/import_empleados.py
+++ b/export_lsd/tools/import_empleados.py
@@ -95,6 +95,13 @@ def new_employees_from_xlsx(filepath: str, empresa: SimpleLazyObject):
     bulk_mgr = BulkCreateManager()
 
     for index, row in df.iterrows():
+        # Puede suceder que haya filas sin información y que de todas formas se lea, por eso
+        # Si leg es NaN, no lo tomo y termino el loop
+        if pd.isna(row['Leg']):
+            break
+        # En caso de que el CUIL se informe como float lo cambio a int
+        if isinstance(row['CUIL'], float):
+                row['CUIL'] = int(row['CUIL'])
         cbu = None if pd.isna(row['CBU']) else row['CBU']
         if Empleado.objects.filter(leg=row['Leg'], empresa=empresa).count() == 0:
             bulk_mgr.add(Empleado(empresa=empresa, leg=row['Leg'], name="Creado por Importación",

--- a/export_lsd/tools/import_empleados.py
+++ b/export_lsd/tools/import_empleados.py
@@ -101,7 +101,7 @@ def new_employees_from_xlsx(filepath: str, empresa: SimpleLazyObject):
             break
         # En caso de que el CUIL se informe como float lo cambio a int
         if isinstance(row['CUIL'], float):
-                row['CUIL'] = int(row['CUIL'])
+            row['CUIL'] = int(row['CUIL'])
         cbu = None if pd.isna(row['CBU']) else row['CBU']
         if Empleado.objects.filter(leg=row['Leg'], empresa=empresa).count() == 0:
             bulk_mgr.add(Empleado(empresa=empresa, leg=row['Leg'], name="Creado por Importación",


### PR DESCRIPTION
## Lectura excel info empleados hasta que fila vacía
fixes #34 

Se identificaban excel con información vacía que generaba error
A la vez si se cambiaba el formato de la columna CUIL como float, generaba error también. Se cambia a int antes de pasar a string.